### PR TITLE
src -> source

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var natives = process.binding('natives')
 var module = require('module')
 var normalRequire = require
-exports.src = src
+exports.source = src
 exports.require = req
 var vm = require('vm')
 


### PR DESCRIPTION
In example, `require('natives').source` is exposed, but in source, it's `exports.src = src`, just fix the source.